### PR TITLE
Allow django.urls.include without a namespace

### DIFF
--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -24,7 +24,7 @@ def iter_resolved_urls(url_patterns, namespace_path=[]):
     url_patterns_resolved = []
     for entry in url_patterns:
         if hasattr(entry, 'url_patterns'):
-            if hasattr(entry, 'namespace'):
+            if getattr(entry, 'namespace', None) is not None:
                 url_patterns_resolved += iter_resolved_urls(
                     entry.url_patterns, namespace_path + [entry.namespace])
             else:


### PR DESCRIPTION
`URLResolver.namespace` is set to None by default, which raises `TypeError` for `':'.join(namespaces)`. This breaks any apps or includes not using namespaces (like `django.contrib.admin`).

Example:
```
urlpatterns = [
    distill_path('', views.index, name='index', distill_func=lambda: None),
    path('other/', include([
        path('', views.other, name='other'),
    ])),
]
```