### PR TITLE
Added option to ignore errors on distill rendering

### DIFF
--- a/django_distill/distill.py
+++ b/django_distill/distill.py
@@ -7,7 +7,7 @@ urls_to_distill = []
 def _distill_url(func, *a, **k):
     distill_func = k.get('distill_func')
     distill_file = k.get('distill_file')
-    ignore_errors = k.pop('ignore_errors') or False
+    ignore_errors = k.pop('ignore_errors', None) or False
     if distill_file:
         del k['distill_file']
     if distill_func:

--- a/django_distill/distill.py
+++ b/django_distill/distill.py
@@ -7,6 +7,7 @@ urls_to_distill = []
 def _distill_url(func, *a, **k):
     distill_func = k.get('distill_func')
     distill_file = k.get('distill_file')
+    ignore_errors = k.pop('ignore_errors') or False
     if distill_file:
         del k['distill_file']
     if distill_func:
@@ -18,7 +19,7 @@ def _distill_url(func, *a, **k):
             err = 'Distill function not callable: {}'
             raise DistillError(err.format(distill_func))
         url = func(*a, **k)
-        urls_to_distill.append((url, distill_func, distill_file, name, a, k))
+        urls_to_distill.append((url, distill_func, distill_file, name, ignore_errors, a, k))
     else:
         e = 'URL registered with distill_url but no distill function supplied'
         raise DistillWarning(e)

--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -116,6 +116,8 @@ class DistillRender(object):
                 except DistillError:
                     if not ignore_errors:
                         raise
+                    else:
+                        continue
                 # rewrite URIs ending with a slash to ../index.html
                 if file_name is None and uri.endswith('/'):
                     if uri.startswith('/'):

--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -104,14 +104,18 @@ class DistillRender(object):
         translation.activate(settings.LANGUAGE_CODE)
 
     def render(self):
-        for url, distill_func, file_name, view_name, a, k in self.urls_to_distill:
+        for url, distill_func, file_name, view_name, ignore_errors, a, k in self.urls_to_distill:
             for param_set in self.get_uri_values(distill_func):
                 if not param_set:
                     param_set = ()
                 elif self._is_str(param_set):
                     param_set = param_set,
                 uri = self.generate_uri(url, view_name, param_set)
-                render = self.render_view(uri, param_set, a)
+                try:
+                    render = self.render_view(uri, param_set, a)
+                except DistillError:
+                    if not ignore_errors:
+                        raise
                 # rewrite URIs ending with a slash to ../index.html
                 if file_name is None and uri.endswith('/'):
                     if uri.startswith('/'):


### PR DESCRIPTION
Added option to ignore non-200 errors on page rending using distill.
Usage:
```
distill_path(
    "page.html",
    MyView.as_view(),
    name="myview",
    ignore_errors=True
)
```