### PR TITLE
Fix typo

### DIFF
--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -155,7 +155,7 @@ class DistillRender(object):
             try:
                 uri = reverse(view_name, kwargs=param_set)
             except NoReverseMatch:
-                uri = reverse(view_name_ns, args=param_set)
+                uri = reverse(view_name_ns, kwargs=param_set)
         else:
             err = 'Distill function returned an invalid type: {}'
             raise DistillError(err.format(type(param_set)))


### PR DESCRIPTION
In section with dict params reverse calls with args not kwargs, it doesn't work that way
```
File ".../site-packages/django_distill/renderer.py", line 114, in render
  uri = self.generate_uri(url, view_name, param_set)
File ".../site-packages/django_distill/renderer.py", line 159, in generate_uri
  uri = reverse(view_name_ns, args=param_set)
...  
django.urls.exceptions.NoReverseMatch: Reverse for 'detail' with arguments '('pk', 'slug')' not found. 1 pattern(s) tried: ['blog/(?P<slug>[^/]+)_(?P<pk>[0-9]+)/$']
```