### PR TITLE
Declare backend dependencies on the setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ render_single_file(
 ```
 
 which would write out the contents of `/post/123_blog-title-slug.html` into
-`/path/to/output/directory` as the file 
+`/path/to/output/directory` as the file
 `/path/to/output/directory/post/123_blog-title-slug.html`. Note any required
 sub-directories (`/path/to/output/directory/post` in this example) will be
 automatically created if they don't already exist. All `django-distill` rules
@@ -444,7 +444,7 @@ Django by changing the backend database engine. Currently the engines supported
 by `django-distill` are:
 
 **django_distill.backends.amazon_s3**: Publish to an Amazon S3 bucket. Requires
-  the Python library `boto3` (`$ pip install boto3`). The bucket must already
+  the Python library `boto3` (`$ pip install django-distill[amazon]`). The bucket must already
   exist (use the AWS control panel). Options:
 
 ```python
@@ -460,7 +460,7 @@ by `django-distill` are:
 **django_distill.backends.google_storage**: Publish to a Google Cloud Storage
   bucket. Requires the Python libraries `google-api-python-client` and
   `google-cloud-storage`
-  (`$ pip install google-api-python-client google-cloud-storage`). The bucket
+  (`$ pip install django-distill[google]`). The bucket
   must already exist and be set up to host a public static website (use the
   Google Cloud control panel). Options:
 
@@ -475,7 +475,7 @@ by `django-distill` are:
 
 **django_distill.backends.microsoft_azure_storage**: Publish to a Microsoft
   Azure Blob Storage container. Requires the Python library
-  `azure-storage-blob` (`$ pip install azure-storage-blob`). The storage
+  `azure-storage-blob` (`$ pip install django-distill[microsoft]`). The storage
   account must already exist and be set up to host a public static website
   (use the Microsoft Azure control panel). Options:
 

--- a/django_distill/backends/amazon_s3.py
+++ b/django_distill/backends/amazon_s3.py
@@ -7,7 +7,7 @@ except ImportError:
     name = 'django_distill.backends.amazon_s3'
     pipm = 'boto3'
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
-    sys.stdout.write('$ pip install {}\n\n'.format(pipm))
+    sys.stdout.write('$ pip install .[amazon-s3]{}\n\n'.format(pipm))
     raise
 
 

--- a/django_distill/backends/amazon_s3.py
+++ b/django_distill/backends/amazon_s3.py
@@ -7,7 +7,7 @@ except ImportError:
     name = 'django_distill.backends.amazon_s3'
     pipm = 'boto3'
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
-    sys.stdout.write('$ pip install .[amazon-s3]{}\n\n'.format(pipm))
+    sys.stdout.write('$ pip install .[amazon]{}\n\n'.format(pipm))
     raise
 
 

--- a/django_distill/backends/google_storage.py
+++ b/django_distill/backends/google_storage.py
@@ -12,7 +12,7 @@ except ImportError:
     name = 'django_distill.backends.google_storage'
     pipm = 'google-api-python-client google-cloud-storage'
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
-    sys.stdout.write('$ pip install {}\n\n'.format(pipm))
+    sys.stdout.write('$ pip install .[google-storage]{}\n\n'.format(pipm))
     raise
 
 

--- a/django_distill/backends/google_storage.py
+++ b/django_distill/backends/google_storage.py
@@ -12,7 +12,7 @@ except ImportError:
     name = 'django_distill.backends.google_storage'
     pipm = 'google-api-python-client google-cloud-storage'
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
-    sys.stdout.write('$ pip install .[google-storage]{}\n\n'.format(pipm))
+    sys.stdout.write('$ pip install .[google]{}\n\n'.format(pipm))
     raise
 
 

--- a/django_distill/backends/microsoft_azure_storage.py
+++ b/django_distill/backends/microsoft_azure_storage.py
@@ -13,7 +13,7 @@ except ImportError:
     name = 'django_distill.backends.azure_storage'
     pipm = 'azure-storage-blob'
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
-    sys.stdout.write('$ pip install .[microsoft-azure]{}\n\n'.format(pipm))
+    sys.stdout.write('$ pip install .[microsoft]{}\n\n'.format(pipm))
     raise
 
 

--- a/django_distill/backends/microsoft_azure_storage.py
+++ b/django_distill/backends/microsoft_azure_storage.py
@@ -13,7 +13,7 @@ except ImportError:
     name = 'django_distill.backends.azure_storage'
     pipm = 'azure-storage-blob'
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
-    sys.stdout.write('$ pip install {}\n\n'.format(pipm))
+    sys.stdout.write('$ pip install .[microsoft-azure]{}\n\n'.format(pipm))
     raise
 
 
@@ -37,7 +37,7 @@ class AzureBlobStorateBackend(BackendBase):
 
     def account_username(self):
         return
-    
+
     def account_container(self):
         return '$web'
 

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     include_package_data = True,
     install_requires = requirements,
     extras_require = {
-        'amazon-s3': ['boto3'],
-        'google-storage': ['google-api-python-client', 'google-cloud-storage'],
-        'microsoft-azure': ['azure-storage-blob'],
+        'amazon': ['boto3'],
+        'google': ['google-api-python-client', 'google-cloud-storage'],
+        'microsoft': ['azure-storage-blob'],
     },
     packages = find_packages(),
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ setup(
     license = 'MIT',
     include_package_data = True,
     install_requires = requirements,
+    extras_require = {
+        'amazon-s3': ['boto3'],
+        'google-storage': ['google-api-python-client', 'google-cloud-storage'],
+        'microsoft-azure': ['azure-storage-blob'],
+    },
     packages = find_packages(),
     classifiers = [
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Declare backend dependencies on the setup.py file instead.

Installing an Amazon S3 backend results in:

`pip install django-distill[amazon]`

The naming convention follows the company name but could also be [company-product] in case more are supported.