### PR TITLE
Added option to do multi-threaded uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ rendering, this is just a shortcut to save you typing an extra command.
 `--exclude-staticfiles`: Do not copy any static files at all, only render output from
 Django views.
 
+`--skip-verify`: Do not test if files are correctly uploaded on the server.
+
+
 **Note** that this means if you use `--force` and `--quiet` that the output
 directory will have all files not part of the site export deleted without any
 confirmation.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Django views.
 
 `--skip-verify`: Do not test if files are correctly uploaded on the server.
 
+`--parallel-publish [number of threads]`: Publish files in parallel on multiple threads, this can speed up upload. Defaults to 1 thread.
 
 **Note** that this means if you use `--force` and `--quiet` that the output
 directory will have all files not part of the site export deleted without any

--- a/django_distill/management/commands/distill-publish.py
+++ b/django_distill/management/commands/distill-publish.py
@@ -24,6 +24,7 @@ class Command(BaseCommand):
         parser.add_argument('--exclude-staticfiles', dest='exclude_staticfiles',
                     action='store_true')
         parser.add_argument('--skip-verify', dest='skip_verify', action='store_true')
+        parser.add_argument('--parallel-publish', dest='parallel_publish', type=int, default=1)
 
     def _quiet(self, *args, **kwargs):
         pass
@@ -45,6 +46,7 @@ class Command(BaseCommand):
         collectstatic = options.get('collectstatic')
         exclude_staticfiles = options.get('exclude_staticfiles')
         skip_verify = options.get('skip_verify', False)
+        parallel_publish = options.get('parallel_publish')
         quiet = options.get('quiet')
         force = options.get('force')
         if quiet:
@@ -94,7 +96,7 @@ class Command(BaseCommand):
             stdout('')
             stdout('Publishing site')
             backend.index_local_files()
-            publish_dir(output_dir, backend, stdout, not skip_verify)
+            publish_dir(output_dir, backend, stdout, not skip_verify, parallel_publish)
         finally:
             if os.path.exists(output_dir):
                 stdout('Deleting temporary directory.')

--- a/django_distill/management/commands/distill-publish.py
+++ b/django_distill/management/commands/distill-publish.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
         parser.add_argument('--force', dest='force', action='store_true')
         parser.add_argument('--exclude-staticfiles', dest='exclude_staticfiles',
                     action='store_true')
+        parser.add_argument('--skip-verify', dest='skip_verify', action='store_true')
 
     def _quiet(self, *args, **kwargs):
         pass
@@ -43,6 +44,7 @@ class Command(BaseCommand):
             raise CommandError(e)
         collectstatic = options.get('collectstatic')
         exclude_staticfiles = options.get('exclude_staticfiles')
+        skip_verify = options.get('skip_verify', False)
         quiet = options.get('quiet')
         force = options.get('force')
         if quiet:
@@ -92,7 +94,7 @@ class Command(BaseCommand):
             stdout('')
             stdout('Publishing site')
             backend.index_local_files()
-            publish_dir(output_dir, backend, stdout)
+            publish_dir(output_dir, backend, stdout, not skip_verify)
         finally:
             if os.path.exists(output_dir):
                 stdout('Deleting temporary directory.')

--- a/django_distill/publisher.py
+++ b/django_distill/publisher.py
@@ -1,7 +1,7 @@
 from django_distill.errors import DistillPublishError
 
 
-def publish_dir(local_dir, backend, stdout):
+def publish_dir(local_dir, backend, stdout, verify=True):
     stdout('Authenticating')
     backend.authenticate()
     stdout('Getting file indexes')
@@ -33,11 +33,12 @@ def publish_dir(local_dir, backend, stdout):
         remote_f = backend.remote_path(f)
         stdout('Publishing: {} -> {}'.format(f, remote_f))
         backend.upload_file(f, backend.remote_path(f))
-        url = backend.remote_url(f)
-        stdout('Verifying: {}'.format(url))
-        if not backend.check_file(f, url):
-            err = 'Remote file {} failed hash check'
-            raise DistillPublishError(err.format(url))
+        if verify:
+            url = backend.remote_url(f)
+            stdout('Verifying: {}'.format(url))
+            if not backend.check_file(f, url):
+                err = 'Remote file {} failed hash check'
+                raise DistillPublishError(err.format(url))
     # Call any final checks that may be needed by the backend
     stdout('Final checks')
     backend.final_checks()


### PR DESCRIPTION
Note: this PR comes after #75 

This adds an option to use multiple threads to upload file to the remote storage. This can save a lot of time for large sites.