### PR TITLE
Skip delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ rendering, this is just a shortcut to save you typing an extra command.
 `--exclude-staticfiles`: Do not copy any static files at all, only render output from
 Django views.
 
+`--skip-verify`: Do not test if files are correctly uploaded on the server.
+
+
 **Note** that this means if you use `--force` and `--quiet` that the output
 directory will have all files not part of the site export deleted without any
 confirmation.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Django views.
 
 `--skip-verify`: Do not test if files are correctly uploaded on the server.
 
+`--ignore-remote-content`: Do not fetch the list of remote files. It means that all files will be uploaded, and no existing remote file will be  deleted. This can be useful if you have a lot of files on the remote server, and you know that you want to update most of them, and you don't care if old files remain on the server.
+
 `--parallel-publish [number of threads]`: Publish files in parallel on multiple threads, this can speed up upload. Defaults to 1 thread.
 
 **Note** that this means if you use `--force` and `--quiet` that the output

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Django views.
 
 `--skip-verify`: Do not test if files are correctly uploaded on the server.
 
+`--parallel-publish [number of threads]`: Publish files in parallel on multiple threads, this can speed up upload. Defaults to 1 thread.
 
 **Note** that this means if you use `--force` and `--quiet` that the output
 directory will have all files not part of the site export deleted without any

--- a/django_distill/management/commands/distill-publish.py
+++ b/django_distill/management/commands/distill-publish.py
@@ -1,6 +1,5 @@
 import os
-from tempfile import mkdtemp
-from shutil import rmtree
+import tempfile
 from django.conf import settings
 from django.core.management.base import (BaseCommand, CommandError)
 from django_distill.backends import get_backend
@@ -24,6 +23,7 @@ class Command(BaseCommand):
         parser.add_argument('--exclude-staticfiles', dest='exclude_staticfiles',
                     action='store_true')
         parser.add_argument('--skip-verify', dest='skip_verify', action='store_true')
+        parser.add_argument('--ignore-remote-content', dest='ignore_remote_content', action='store_true')
         parser.add_argument('--parallel-publish', dest='parallel_publish', type=int, default=1)
 
     def _quiet(self, *args, **kwargs):
@@ -47,15 +47,14 @@ class Command(BaseCommand):
         exclude_staticfiles = options.get('exclude_staticfiles')
         skip_verify = options.get('skip_verify', False)
         parallel_publish = options.get('parallel_publish')
+        ignore_remote_content = options.get('ignore_remote_content', False)
         quiet = options.get('quiet')
         force = options.get('force')
         if quiet:
             stdout = self._quiet
         else:
             stdout = self.stdout.write
-        static_url = settings.STATIC_URL
-        try:
-            output_dir = mkdtemp()
+        with tempfile.TemporaryDirectory() as output_dir:
             if not output_dir.endswith(os.sep):
                 output_dir += os.sep
             backend_class = get_backend(publish_engine)
@@ -96,10 +95,7 @@ class Command(BaseCommand):
             stdout('')
             stdout('Publishing site')
             backend.index_local_files()
-            publish_dir(output_dir, backend, stdout, not skip_verify, parallel_publish)
-        finally:
-            if os.path.exists(output_dir):
-                stdout('Deleting temporary directory.')
-                rmtree(output_dir)
+            publish_dir(backend, stdout, not skip_verify, parallel_publish, ignore_remote_content)
+
         stdout('')
         stdout('Site generation and publishing complete.')

--- a/django_distill/management/commands/distill-publish.py
+++ b/django_distill/management/commands/distill-publish.py
@@ -24,6 +24,7 @@ class Command(BaseCommand):
         parser.add_argument('--exclude-staticfiles', dest='exclude_staticfiles',
                     action='store_true')
         parser.add_argument('--skip-verify', dest='skip_verify', action='store_true')
+        parser.add_argument('--parallel-publish', dest='parallel_publish', type=int, default=1)
 
     def _quiet(self, *args, **kwargs):
         pass
@@ -45,6 +46,7 @@ class Command(BaseCommand):
         collectstatic = options.get('collectstatic')
         exclude_staticfiles = options.get('exclude_staticfiles')
         skip_verify = options.get('skip_verify', False)
+        parallel_publish = options.get('parallel_publish')
         quiet = options.get('quiet')
         force = options.get('force')
         if quiet:
@@ -94,7 +96,7 @@ class Command(BaseCommand):
             stdout('')
             stdout('Publishing site')
             backend.index_local_files()
-            publish_dir(output_dir, backend, stdout, not skip_verify)
+            publish_dir(output_dir, backend, stdout, not skip_verify, parallel_publish)
         finally:
             if os.path.exists(output_dir):
                 stdout('Deleting temporary directory.')

--- a/django_distill/management/commands/distill-publish.py
+++ b/django_distill/management/commands/distill-publish.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
         parser.add_argument('--force', dest='force', action='store_true')
         parser.add_argument('--exclude-staticfiles', dest='exclude_staticfiles',
                     action='store_true')
+        parser.add_argument('--skip-verify', dest='skip_verify', action='store_true')
 
     def _quiet(self, *args, **kwargs):
         pass
@@ -43,6 +44,7 @@ class Command(BaseCommand):
             raise CommandError(e)
         collectstatic = options.get('collectstatic')
         exclude_staticfiles = options.get('exclude_staticfiles')
+        skip_verify = options.get('skip_verify', False)
         quiet = options.get('quiet')
         force = options.get('force')
         if quiet:
@@ -92,7 +94,7 @@ class Command(BaseCommand):
             stdout('')
             stdout('Publishing site')
             backend.index_local_files()
-            publish_dir(output_dir, backend, stdout)
+            publish_dir(output_dir, backend, stdout, not skip_verify)
         finally:
             if os.path.exists(output_dir):
                 stdout('Deleting temporary directory.')

--- a/django_distill/publisher.py
+++ b/django_distill/publisher.py
@@ -42,16 +42,16 @@ def publish_dir(backend, stdout, verify=True, parallel_publish=1, ignore_remote_
 
 def _publish_file(backend, f, verify, stdout):
     remote_f = backend.remote_path(f)
-    stdout('Publishing: {} -> {}'.format(f, remote_f))
+    stdout(f'Publishing: {f} -> {remote_f}')
     backend.upload_file(f, backend.remote_path(f))
     if verify:
         url = backend.remote_url(f)
-        stdout('Verifying: {}'.format(url))
+        stdout(f'Verifying: {url}')
         if not backend.check_file(f, url):
-            err = 'Remote file {} failed hash check'
-            raise DistillPublishError(err.format(url))
+            err = f'Remote file {url} failed hash check'
+            raise DistillPublishError(err)
 
 
 def _delete_file(backend, f, stdout):
-    stdout('Deleting remote: {}'.format(f))
+    stdout(f'Deleting remote: {f}')
     backend.delete_remote_file(f)

--- a/django_distill/publisher.py
+++ b/django_distill/publisher.py
@@ -1,7 +1,7 @@
 from django_distill.errors import DistillPublishError
 
 
-def publish_dir(local_dir, backend, stdout):
+def publish_dir(local_dir, backend, stdout, verify=True):
     stdout('Authenticating')
     backend.authenticate()
     stdout('Getting file indexes')
@@ -33,11 +33,12 @@ def publish_dir(local_dir, backend, stdout):
         remote_f = backend.remote_path(f)
         stdout('Publishing: {} -> {}'.format(f, remote_f))
         backend.upload_file(f, backend.remote_path(f))
-        url = backend.remote_url(f)
-        stdout('Verifying: {}'.format(url))
-        if not backend.check_file(f, url):
-            err = 'Remote file {} failed hash check'
-            raise DistillPublishError(err.format(url))
+        if verify:
+            url = backend.remote_url(f)
+            stdout('Verifying: {}'.format(url))
+            if not backend.check_file(f, url):
+                err = 'Remote file {} failed hash check'
+                raise DistillPublishError(err.format(url))
     # Call any final checks that may be needed by the backend
     stdout('Final checks')
     backend.final_checks()

--- a/django_distill/publisher.py
+++ b/django_distill/publisher.py
@@ -3,11 +3,11 @@ from concurrent.futures import ThreadPoolExecutor
 from django_distill.errors import DistillPublishError
 
 
-def publish_dir(local_dir, backend, stdout, verify=True, parallel_publish=1):
+def publish_dir(backend, stdout, verify=True, parallel_publish=1, ignore_remote_content=False):
     stdout('Authenticating')
     backend.authenticate()
     stdout('Getting file indexes')
-    remote_files = backend.list_remote_files()
+    remote_files = set() if ignore_remote_content else backend.list_remote_files()
     local_files = backend.list_local_files()
     to_upload = set()
     to_delete = set()


### PR DESCRIPTION
Note: this PR comes after #76 and #75 

Once again, the goal is to save time for large sites by not listing remote content. It also means that:
* all files will be uploaded (so efficient if you know that you changed most of them)
* no old file will be removed

There's also some code cleanup, to use the simpler temporary directory features.