### PR TITLE
Refactored AWS S3 backend to work correctly with boto3 to upload files to a S3 bucket.

### DIFF
--- a/django_distill/backends/amazon_s3.py
+++ b/django_distill/backends/amazon_s3.py
@@ -1,5 +1,5 @@
 import sys
-
+import mimetypes
 
 try:
     import boto3
@@ -9,7 +9,6 @@ except ImportError:
     sys.stdout.write('{} backend requires {}:\n'.format(name, pipm))
     sys.stdout.write('$ pip install .[amazon]{}\n\n'.format(pipm))
     raise
-
 
 from django_distill.errors import DistillPublishError
 from django_distill.backends import BackendBase
@@ -25,7 +24,7 @@ class AmazonS3Backend(BackendBase):
 
     def _get_object(self, name):
         bucket = self.account_container()
-        return self.d['connection'].get_object(Bucket=bucket, Key=name)
+        return self.d['connection'].head_object(Bucket=bucket, Key=name)
 
     def account_username(self):
         return self.options.get('ACCESS_KEY_ID', '')
@@ -39,29 +38,33 @@ class AmazonS3Backend(BackendBase):
         bucket = self.account_container()
         self.d['connection'] = boto3.client('s3', aws_access_key_id=access_key_id,
                                             aws_secret_access_key=secret_access_key)
-        self.d['bucket'] = self.d['connection'].get_bucket(bucket)
+        self.d['bucket'] = bucket
 
     def list_remote_files(self):
         rtn = set()
-        for obj in self.d['bucket'].objects.all():
-            rtn.add(obj.key)
+        response = self.d['connection'].list_objects_v2(Bucket=self.d['bucket'])
+        if 'Contents' in response:
+            for obj in response['Contents']:
+                rtn.add(obj['Key'])
         return rtn
 
     def delete_remote_file(self, remote_name):
-        obj = self._get_object(remote_name)
-        return obj.delete()
+        self.d['connection'].delete_object(Bucket=self.d['bucket'], Key=remote_name)
 
     def compare_file(self, local_name, remote_name):
         obj = self._get_object(remote_name)
         local_hash = self._get_local_file_hash(local_name)
-        return local_hash == obj.e_tag[1:-1]
+        return local_hash == obj['ETag'][1:-1]
 
     def upload_file(self, local_name, remote_name):
-        return self.d['bucket'].upload_file(local_name, remote_name)
+        content_type, _ = mimetypes.guess_type(local_name)
+        if content_type is None:
+            content_type = 'application/octet-stream'
+        extra_args = {'ContentType': content_type}
+        self.d['connection'].upload_file(local_name, self.d['bucket'], remote_name, ExtraArgs=extra_args)
 
     def create_remote_dir(self, remote_dir_name):
         # not required for S3 buckets
         return True
-
 
 backend_class = AmazonS3Backend


### PR DESCRIPTION
- Changes the logic in the file amazon_s3.py to update the code to work correctly with the last version of boto3. The current code in the library is broken.

It raised the following error: `AttributeError: 'S3' object has no attribute 'get_bucket'. Did you mean: 'head_bucket'?`

The updated code was tested using the current commands in the documentation, and it's working correctly; I could submit a website to an S3 bucket in AWS S3. Please merge this solution.