### PR TITLE
make JSON_CREDENTIALS optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,10 +478,13 @@ by `django-distill` are:
 'some-google-storage-bucket': {
     'ENGINE': 'django_distill.backends.google_storage',
     'PUBLIC_URL': 'https://storage.googleapis.com/[bucket.name.here]/',
-    'JSON_CREDENTIALS': '/path/to/some/credentials.json',
     'BUCKET': '[bucket.name.here]',
+    'JSON_CREDENTIALS': '/path/to/some/credentials.json',
 },
 ```
+
+Note that `JSON_CREDENTIALS` is optional; if it is not specified, the google libraries will try other authentication methods, in the search order described here: https://cloud.google.com/docs/authentication/application-default-credentials (e.g. the GOOGLE_APPLICATION_CREDENTIALS environment variable, an attached service account, etc).
+
 
 **django_distill.backends.microsoft_azure_storage**: Publish to a Microsoft
   Azure Blob Storage container. Requires the Python library

--- a/django_distill/backends/google_storage.py
+++ b/django_distill/backends/google_storage.py
@@ -25,7 +25,7 @@ class GoogleCloudStorageBackend(BackendBase):
         Publisher for Google Cloud Storage. Implements the BackendBase.
     '''
 
-    REQUIRED_OPTIONS = ('ENGINE', 'JSON_CREDENTIALS', 'BUCKET')
+    REQUIRED_OPTIONS = ('ENGINE', 'BUCKET')
 
     def account_username(self):
         return
@@ -35,10 +35,12 @@ class GoogleCloudStorageBackend(BackendBase):
 
     def authenticate(self):
         credentials_file = self.options.get('JSON_CREDENTIALS', '')
-        if not os.path.exists(credentials_file):
-            err = 'Credentials file does not exist: {}'
-            raise DistillPublishError(err.format(credentials_file))
-        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = credentials_file
+        if credentials_file:
+            if not os.path.exists(credentials_file):
+                err = 'Credentials file does not exist: {}'
+                raise DistillPublishError(err.format(credentials_file))
+            os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = credentials_file
+        
         bucket = self.account_container()
         self.d['connection'] = storage.Client()
         self.d['bucket'] = self.d['connection'].get_bucket(bucket)


### PR DESCRIPTION
The JSON_CREDENTIALS value should be optional.

- The google client libraries support alternate authentication methods, so users shouldn't be forced to only use the json credentials file method 
- My company's security policy forbids the use of json key files stored on compute instances in production, so the json credentials file method is not an option for me
- Simply making the JSON_CREDENTIALS option optional allows the underlying Google libraries to just do the right thing as regards the ADC search order (see https://cloud.google.com/docs/authentication/application-default-credentials )
- This PR will look for the JSON_CREDENTIALS file if that option is present, and just lets ADC do its thing if not.
