### PR TITLE
Add resolver match to request

### DIFF
--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -75,11 +75,12 @@ class DistillHandler(ClientHandler):
     def resolve_request(self, request):
         for arg in self.view_args:
             self.view_uri_kwargs.update(**arg)
-        return ResolverMatch(
+        request.resolver_match = ResolverMatch(
             self.view_func,
             self.view_uri_args,
             self.view_uri_kwargs,
         )
+        return request.resolver_match
 
     def load_middleware(self, is_async=False):
         '''

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -425,3 +425,14 @@ class DjangoDistillRendererTestSuite(TestCase):
             b'',
         ])
         self.assertEqual(render.content, expected)
+
+    def test_request_has_resolver_match(self):
+        view = self._get_view("test-has-resolver-match")
+        assert view
+        view_url, view_func, file_name, status_codes, view_name, args, kwargs = view
+        param_set = self.renderer.get_uri_values(view_func, view_name)[0]
+        if not param_set:
+            param_set = ()
+        uri = self.renderer.generate_uri(view_url, view_name, param_set)
+        render = self.renderer.render_view(uri, status_codes, param_set, args, kwargs)
+        self.assertEqual(render.content, b"test_request_has_resolver_match")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -94,6 +94,10 @@ def test_flatpages_func():
         yield {'url': flatpage.url}
 
 
+def test_request_has_resolver_match(request):
+    return HttpResponse(request.resolver_match.func.__name__)
+
+
 urlpatterns = [
 
     path('path/namespace1/',
@@ -217,6 +221,11 @@ if settings.HAS_PATH:
             name='test-kwargs'),
         distill_path('path/humanize',
             test_humanize_view,
-            name='test-humanize')
+            name='test-humanize'),
+        distill_path(
+            "path/has-resolver-match",
+            test_request_has_resolver_match,
+            name="test-has-resolver-match",
+        ),
 
     ]


### PR DESCRIPTION
Hi @meeb, I found a pretty esoteric bug in distill. I have some views that happen to rely on the `request.resolver_match` object for some logic, but distill's override of `resolve_request` doesn't attach the resolver match to the request as [Django's does](https://github.com/django/django/blob/e16d0c176e9b89628cdec5e58c418378c4a2436a/django/core/handlers/base.py#L312). Here's a patch (with test) to correct that issue.