### PR TITLE
Expand ci test matrix to cover multiple Django versions, latest Python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.10', 'pypy3.11']
+        django-version: ['3.2', '4.2', '5.2', '6.0']
+        exclude:
+          - django-version: '3.2'
+            python-version: '3.11'
+          - django-version: '3.2'
+            python-version: '3.12'
+          - django-version: '3.2'
+            python-version: '3.13'
+          - django-version: '3.2'
+            python-version: '3.14'
+          - django-version: '4.2'
+            python-version: '3.13'
+          - django-version: '4.2'
+            python-version: '3.14'
+          - django-version: '6.0'
+            python-version: '3.10'
+          - django-version: '6.0'
+            python-version: '3.11'
+          - django-version: '6.0'
+            python-version: 'pypy3.10'
+          - django-version: '6.0'
+            python-version: 'pypy3.11'
     steps:
       - uses: actions/checkout@v4
       - name: Install Python ${{ matrix.python-version }}
@@ -23,5 +45,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install "Django==${{ matrix.django-version }}.*"
       - name: Run Django tests
         run: ./run-tests.py


### PR DESCRIPTION
For peace of mind... run tests against multiple Django versions

Also add the newer Python versions, and drop EOL deprecated versions (which were already tested in the past)